### PR TITLE
refactor: webpack version up 4 to 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,35 +1,34 @@
 {
-    "name": "es6-webpack-seed",
-    "version": "1.0.0",
-    "description": "webpack seed",
-    "main": "index.js",
-    "scripts": {
-        "build": "cross-env NODE_ENV=development webpack --mode development",
-        "build-prod": "cross-env NODE_ENV=production webpack --mode production",
-        "dev": "webpack-dev-server --open --mode development"
-    },
-    "author": "",
-    "license": "ISC",
-    "devDependencies": {
-        "@babel/core": "^7.4.5",
-        "@babel/preset-env": "^7.4.5",
-        "babel-loader": "^8.0.6",
-        "browser-sync-client": "^2.26.6",
-        "clean-webpack-plugin": "^3.0.0",
-        "cross-env": "~5.2",
-        "css-loader": "^3.0.0",
-        "cssnano": "~4.1",
-        "html-webpack-plugin": "^3.2.0",
-        "optimize-css-assets-webpack-plugin": "~5.0",
-        "style-loader": "^0.23.1",
-        "uglifyjs-webpack-plugin": "~2.0",
-        "webpack": "^4.34.0",
-        "webpack-bundle-analyzer": "^3.3.2",
-        "webpack-cli": "^3.3.4",
-        "webpack-dev-server": "^3.7.1",
-        "webpack-merge": "~4.2"
-    },
-    "dependencies": {
-        "d3": "^5.9.2"
-    }
+  "name": "es6-webpack-seed",
+  "version": "1.0.0",
+  "description": "webpack seed",
+  "main": "index.js",
+  "scripts": {
+    "build": "cross-env NODE_ENV=development webpack --mode development",
+    "build-prod": "cross-env NODE_ENV=production webpack --mode production",
+    "dev": "webpack-dev-server --open --mode development"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "babel-loader": "^8.0.6",
+    "browser-sync-client": "^2.26.6",
+    "clean-webpack-plugin": "^3.0.0",
+    "cross-env": "~5.2",
+    "css-loader": "^3.0.0",
+    "cssnano": "~4.1",
+    "html-webpack-plugin": "^5.5.0",
+    "optimize-css-assets-webpack-plugin": "~5.0",
+    "style-loader": "^0.23.1",
+    "uglifyjs-webpack-plugin": "~2.0",
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0",
+    "webpack-dev-server": "^4.9.3",
+    "webpack-merge": "^5.8.0"
+  },
+  "dependencies": {
+    "d3": "^5.9.2"
+  }
 }

--- a/webpack-config/webpack.config.common.js
+++ b/webpack-config/webpack.config.common.js
@@ -1,40 +1,37 @@
 // const path = require('path');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const HtmlWebPackPlugin      = require('html-webpack-plugin');
-const BundleAnalyzerPlugin   = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const HtmlWebPackPlugin = require("html-webpack-plugin");
 
-const helpers = require('./helpers');
- 
+const helpers = require("./helpers");
+
 module.exports = {
-    module: {
-        rules: [
-            {
-            test: /\.js$/,
-            exclude: /node_modules/,
-            use: {
-                loader: 'babel-loader',
-                options: {
-                    presets: ['@babel/preset-env']
-                }
-            }
-            },
-            {
-                test: /\.css$/,
-                use: ['style-loader', 'css-loader']
-            }
-        ]
-    },
-    plugins: [
-        new CleanWebpackPlugin({ 
-            root: helpers.root(), 
-            verbose: true 
-        }),
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env"],
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ["style-loader", "css-loader"],
+      },
+    ],
+  },
+  plugins: [
+    new CleanWebpackPlugin({
+      root: helpers.root(),
+      verbose: true,
+    }),
 
-        new HtmlWebPackPlugin({
-            template: './src/index.html',
-            filename: './index.html'
-        }),
-
-        new BundleAnalyzerPlugin()
-    ]
+    new HtmlWebPackPlugin({
+      template: "./src/index.html",
+      filename: "./index.html",
+    }),
+  ],
 };

--- a/webpack-config/webpack.config.dev.js
+++ b/webpack-config/webpack.config.dev.js
@@ -1,28 +1,28 @@
-'use strict';
+"use strict";
 
-const webpackMerge = require('webpack-merge');
+const { merge } = require("webpack-merge");
 
-const commonConfig = require('./webpack.config.common');
-const helpers      = require('./helpers');
+const commonConfig = require("./webpack.config.common");
+const helpers = require("./helpers");
 
-module.exports = webpackMerge(commonConfig, {
-    mode: 'development',
+module.exports = merge(commonConfig, {
+  mode: "development",
 
-    devtool: 'cheap-module-eval-source-map',
+  devtool: "eval-cheap-source-map",
 
-    output: {
-        path: helpers.root('dist'),
-        publicPath: '/',
-        filename: '[name].bundle.js',
-        chunkFilename: '[id].chunk.js'
-    },
+  output: {
+    path: helpers.root("dist"),
+    publicPath: "/",
+    filename: "[name].bundle.js",
+    chunkFilename: "[id].chunk.js",
+  },
 
-    optimization: {
-        noEmitOnErrors: true
-    },
+  optimization: {
+    noEmitOnErrors: true,
+  },
 
-    devServer: {
-        historyApiFallback: true,
-        stats: 'minimal'
-    }
+  devServer: {
+    historyApiFallback: true,
+    stats: "minimal",
+  },
 });

--- a/webpack-config/webpack.config.prod.js
+++ b/webpack-config/webpack.config.prod.js
@@ -1,50 +1,50 @@
-'use strict';
+"use strict";
 
-const webpackMerge            = require('webpack-merge');
-const UglifyJsPlugin          = require('uglifyjs-webpack-plugin');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
-const cssnano                 = require('cssnano');
+const { merge } = require("webpack-merge");
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
+const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const cssnano = require("cssnano");
 
-const commonConfig            = require('./webpack.config.common');
-const helpers                 = require('./helpers');
+const commonConfig = require("./webpack.config.common");
+const helpers = require("./helpers");
 
-module.exports = webpackMerge(commonConfig, {
-    mode: 'production',
+module.exports = merge(commonConfig, {
+  mode: "production",
 
-    output: {
-        path: helpers.root('dist'),
-        publicPath: '/',
-        filename: '[hash].js',
-        chunkFilename: '[id].[hash].chunk.js'
-    },
+  output: {
+    path: helpers.root("dist"),
+    publicPath: "/",
+    filename: "[hash].js",
+    chunkFilename: "[id].[hash].chunk.js",
+  },
 
-    optimization: {
-        noEmitOnErrors: true,
-        splitChunks: {
-            cacheGroups: {
-                commons: {
-                  test: /[\\/]node_modules[\\/]/,
-                  name: 'vendors',
-                  chunks: 'all'
-                }
-            }
+  optimization: {
+    noEmitOnErrors: true,
+    splitChunks: {
+      cacheGroups: {
+        commons: {
+          test: /[\\/]node_modules[\\/]/,
+          name: "vendors",
+          chunks: "all",
         },
-        runtimeChunk: 'single',
-        minimizer: [
-            new UglifyJsPlugin({
-                cache: true,
-                parallel: true
-            }),
+      },
+    },
+    runtimeChunk: "single",
+    minimizer: [
+      new UglifyJsPlugin({
+        cache: true,
+        parallel: true,
+      }),
 
-            new OptimizeCSSAssetsPlugin({
-                cssProcessor: cssnano,
-                cssProcessorOptions: {
-                    discardComments: {
-                        removeAll: true
-                    }
-                },
-                canPrint: false
-            })
-        ]
-    }
+      new OptimizeCSSAssetsPlugin({
+        cssProcessor: cssnano,
+        cssProcessorOptions: {
+          discardComments: {
+            removeAll: true,
+          },
+        },
+        canPrint: false,
+      }),
+    ],
+  },
 });


### PR DESCRIPTION
[주요 변경사항]
1. webpack관련 패키지들 @latest로 버전업
2. BundleAnalyzerPlugin 제거
3. webpackMerge -> merge 함수 형태로 변경
4. devtool 변경

[참고링크]
https://webpack.kr/migrate/5/#make-sure-your-build-has-no-errors-or-warnings
https://webpack.kr/configuration/devtool/
https://stackoverflow.com/questions/68302157/i-upgraded-my-webpack-v4-to-v5-and-after-that-i-am-getting-a-cannot-add-propert
https://futurestud.io/tutorials/how-to-fix-webpack-merge-is-not-a-function